### PR TITLE
Fix CVSS score in Newly Vulnerable Files table

### DIFF
--- a/data/cvereport.xsl
+++ b/data/cvereport.xsl
@@ -72,10 +72,10 @@ yet to be acknowledged by you.
   </tr>
   <xsl:for-each select="//record[not(File=document('acknowledgements.xml')/acknowledgements/file/@name)][not(File=preceding-sibling::record/File)]">
     <xsl:variable name="fileid" select="File" />
-    <xsl:variable name="cpeid" select="CPE" />
-    <xsl:variable name="cvss" select="CVSS" />
-    <xsl:for-each select="//record[File=$fileid][not(CVE=document('acknowledgements.xml')/acknowledgements/file[@name=$fileid]/@cve)][not(CVE=preceding-sibling::record[File=$fileid]/CVE)]/CVE">
-      <xsl:variable name="cveid" select="." />
+    <xsl:for-each select="//record[File=$fileid][not(CVE=document('acknowledgements.xml')/acknowledgements/file[@name=$fileid]/@cve)][not(CVE=preceding-sibling::record[File=$fileid]/CVE)]">
+      <xsl:variable name="cpeid" select="CPE" />
+      <xsl:variable name="cvss" select="CVSS" />
+      <xsl:variable name="cveid" select="CVE" />
       <tr>
         <td><xsl:value-of select="$fileid" /></td>
 	<td><xsl:value-of select="$cpeid" /></td>


### PR DESCRIPTION
While generating the report, the cvereport script creates a wrong "Newly Vulnerable Files" list. The issue can be detected by comparing this list with the "New CVE Matches" list at the beginning.

This is a bug of the cvereport.xsl script, which takes the wrong CVSS value while looping through the <record> fields of the temporary xml.
