### PR TITLE
Fix crash and invalid line reported on lines without "cpe:/" in watchlist.txt

### DIFF
--- a/src/cvecheck.c
+++ b/src/cvecheck.c
@@ -34,7 +34,10 @@ void string_to_cpe(struct cpe_data * cpe, char * buffer) {
 
 	int fieldwidth = 0;
 
-	cpos = strstr(buffer, "cpe:/")+5;
+	cpos = strstr(buffer, "cpe:/");
+	if (cpos == NULL)
+		return;
+	cpos += 5;
 	nextpos = strchr(cpos, ':');
 
 	if (nextpos == 0)

--- a/src/cvecheck.c
+++ b/src/cvecheck.c
@@ -1173,15 +1173,11 @@ int load_watch_list(struct workstate * ws) {
 			rc = delete_cpe(line, ws);
 			if (rc) {
 				fprintf(stderr, " ! An error occurred while interpreting CPE on line %d\n", linenum-1);
-				zero_string(line, CPELINESIZE);
-				continue;
 			};
 		} else {
 			rc = add_cpe(line, ws);
 			if (rc) {
 				fprintf(stderr, " ! An error occurred while interpreting CPE on line %d\n", linenum-1);
-				zero_string(line, CPELINESIZE);
-				continue;
 			};
 		};
 		zero_string(line, CPELINESIZE);


### PR DESCRIPTION
To trigger this just add 2 blank lines anywhere in your watchlist.txt.