### PR TITLE
cvechecker small bug fixes

### DIFF
--- a/src/cvecheck.c
+++ b/src/cvecheck.c
@@ -997,6 +997,13 @@ int add_cpe(char * line, struct workstate * ws) {
 	char * cdir = (char *) calloc(13, sizeof(char));
 	char * clin = (char *) calloc(BUFFERSIZE*6+7, sizeof(char));
 
+	if ((strlen(line) == 0) || (line[0] == '#'))
+	{
+	  free(cdir);
+	  free(clin);
+	  return 0;
+	}
+
 	string_to_cpe(&cpe, line);
 	cpe_to_string(buffer, BUFFERSIZE, cpe);
 

--- a/src/cvecheck_common.h
+++ b/src/cvecheck_common.h
@@ -21,7 +21,7 @@
 #define LARGEFIELDSIZE 512
 #define FILENAMESIZE 256
 #define BUFFERSIZE 256
-#define CVELINESIZE 16
+#define CVELINESIZE 24 
 #define CPELINESIZE (7 + FIELDSIZE*6 + 5)
 #define VERSIONLINESIZE (FILENAMESIZE*2 + 5 + CPELINESIZE)
 // Normally, around 1800 ought to be enough (largest SELECT statement with assumption of largest values)

--- a/src/sqlite3/sqlite3_impl.c
+++ b/src/sqlite3/sqlite3_impl.c
@@ -847,10 +847,19 @@ int sqlite_dbimpl_process_binary(struct workstate * ws) {
 
 void find_cve_for_cpe(struct workstate * ws, char part, int length, int cpeid, const char * inset) {
   int rc = 0;
+  int count;
   sqlite3_stmt * cve_stmt;
   char stmt[SQLLINESIZE];
 
+  sprintf(stmt, "select count(*) from tb_cve");
+  count = get_int_value(ws->localdb[0], stmt, ws);
+  if (count == 0) {
+    fprintf(stderr, "Local CVE Databse is empty \n");
+    exit(EXIT_FAILURE);
+   }; 
+
   sprintf(stmt, "select distinct a.basedir as basedir, a.filename as filename, b.year as year, b.sequence as sequence, b.cpe as cpeid, b.cvss as cvss from tb_binmatch a, tb_cve b where b.cpe in %s and a.cpe = %d and a.cpepart = b.cpepart and a.cpevendorlength = b.cpevendorlength;", inset, cpeid);
+
   PREPARE_SQLITE(rc, ws->localdb[0], stmt, cve_stmt)
 
   while ((rc = sqlite3_step(cve_stmt)) == SQLITE_ROW) {


### PR DESCRIPTION
The following bugs in cvechecker are fixed in this repository:
-After first if cvechecker is reinitialized and run it does not recognize that the local database is empty and it does not give any out put. This is fixed now and it throws an error informing an empty local database
-There was truncation of data , while loading CVE data from the corresponding csv files into to the databases.This is fixed now and data truncation is prevented.
-Comments and empty lines in watchlist text files will be ignored.Previously cvechecker threw an error.