### PR TITLE
port to OpenBSD and Alpine Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,24 +4,6 @@ AM_INIT_AUTOMAKE([subdir-objects foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 
-AC_MSG_CHECKING([Determining host operating system])
-OSNAME=`uname -s`
-AC_MSG_RESULT($OSNAME)
-case "$OSNAME" in
-  FreeBSD*)
-    # Include the packages - needed for argp_standalone
-    export CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-    export LDFLAGS="$LDFLAGS -L /usr/local/lib"
-    AC_MSG_RESULT([FreeBSD: adding /usr/local])
-    ;;
-  NetBSD*)
-    # Include the packages - needed for argp
-    export CPPFLAGS="$CPPFLAGS -I/usr/pkg/include"
-    export LDFLAGS="$LDFLAGS -L /usr/pkg/lib"
-    AC_MSG_RESULT([NetBSD: adding /usr/pkg])
-    ;;
-esac
-
 # Checks for programs.
 AC_PROG_CC
 AC_GNU_SOURCE
@@ -30,21 +12,39 @@ AC_GNU_SOURCE
 AC_CHECK_HEADERS([stdlib.h],,[AC_MSG_ERROR([stdlib.h header missing])])
 AC_CHECK_HEADERS([string.h],,[AC_MSG_ERROR([string.h header missing])])
 AC_CHECK_HEADERS([unistd.h],,[AC_MSG_ERROR([unistd.h header missing])])
-AC_CHECK_HEADERS([argp.h],,[AC_MSG_ERROR([argp.h header missing (part of GNU coreutils)])])
-AC_CHECK_HEADERS([string.h],,[AC_MSG_ERROR([string.h header missing])])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([gethostname memset regcomp strchr strrchr strstr strlcpy],,
-  [PKG_CHECK_MODULES([BSD], [libbsd])])
+AC_CHECK_FUNCS([gethostname memset regcomp strchr strrchr strstr])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 
+# Checks for dependencies.
 AC_MSG_WARN([Please make sure pkg-config is installed and autoreconf run])
-PKG_CHECK_MODULES([BSD], [libbsd])
+
+# libbsd is obligatory on systems where strlcpy is not in libc.
+# https://man.openbsd.org/strlcpy.3
+# https://libbsd.freedesktop.org/wiki/
+AC_CHECK_FUNC([strlcpy],, [LIBBSD_NEEDED=yes])
+AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
+  PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay])
+])
+
 PKG_CHECK_MODULES([CONFIG], [libconfig >= 1.3])
-CFLAGS="$CFLAGS $CONFIG_CFLAGS"
-LIBS="$LIBS $CONFIG_LIBS $BSD_LIBS"
+
+# The BSD systems don't have packages in the default include/library
+# paths. Let our pkg-config dependencies add those paths for us BEFORE we look
+# for argp.
+CFLAGS="$CFLAGS $CONFIG_CFLAGS $LIBBSD_CFLAGS"
+LIBS="$LIBS $CONFIG_LIBS $LIBBSD_LIBS"
+
+# argp-standalone is obligatory on systems where argp is not in libc.
+# https://www.gnu.org/software/libc/manual/html_node/Argp.html
+# https://github.com/argp-standalone/argp-standalone
+AC_SEARCH_LIBS([argp_parse], [argp],,
+  [AC_MSG_ERROR([argp-standalone dependency missing])]
+)
+
 ## --with configs
 # mysql
 AC_ARG_ENABLE(mysql, [  --enable-mysql	Enable MySQL support])

--- a/src/cvecheck_common.h
+++ b/src/cvecheck_common.h
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <libconfig.h>
 #include <string.h>
-#include <bsd/string.h>
 
 #ifdef _USE_SQLITE3
 #include <sqlite3.h>
@@ -15,7 +14,7 @@
  * Copyright 2010-2020 Sven Vermeulen.
  * Subject to the GNU Public License, version 3.
  */
- 
+
 #ifndef _CVETYPES
 #define _CVETYPES
 
@@ -23,7 +22,7 @@
 #define LARGEFIELDSIZE 512
 #define FILENAMESIZE 256
 #define BUFFERSIZE 256
-#define CVELINESIZE 24 
+#define CVELINESIZE 24
 #define CPELINESIZE (7 + FIELDSIZE*11 + 5)
 #define VERSIONLINESIZE (FILENAMESIZE*2 + 5 + CPELINESIZE)
 // Normally, around 1800 ought to be enough (largest SELECT statement with assumption of largest values)

--- a/src/output/stringscmd.h
+++ b/src/output/stringscmd.h
@@ -1,7 +1,6 @@
 #include <regex.h>
 #include <stdio.h>
 #include <string.h>
-#include <bsd/string.h>
 #include "../cvecheck_common.h"
 #include "../swstring.h"
 
@@ -11,4 +10,4 @@
  */
 
 // strings_extract_version - Method for extracting the version from the file using the strings command
-int strings_extract_version(struct workstate * ws, regex_t * preg, regmatch_t * pmatch, struct cpe_data * cpe); 
+int strings_extract_version(struct workstate * ws, regex_t * preg, regmatch_t * pmatch, struct cpe_data * cpe);


### PR DESCRIPTION
cvedetails needs patches to build on all the BSDs and anything built with the musl libc.
I believe this PR fixes the build on all of them, but I've only tested it on OpenBSD and Alpine Linux.