### PR TITLE
Fix Sqlite segmentation fault root cause

### DIFF
--- a/src/sqlite3/sqlite3_impl.c
+++ b/src/sqlite3/sqlite3_impl.c
@@ -1145,7 +1145,11 @@ int sqlite_dbimpl_store_cve_in_db(struct workstate * ws, char * cveId, char * cp
         string_to_cpe(&cpe, cpeId);
 
 	cvssScore = atoi(cvssNum);
-	cvssScore = cvssScore * 10 + atoi(strchr(cvssNum, '.')+1);
+	if (strchr(cvssNum, '.') != NULL) {
+		cvssScore = cvssScore * 10 + atoi(strchr(cvssNum, '.')+1);
+	} else {
+	        cvssScore = cvssScore * 10;
+        }
 
         ws->rc = 0;
         rc = check_cvecpe_in_sqlite_db(ws, year, sequence, cpe);


### PR DESCRIPTION
If the `strchr` function isn't guarded, it causes a segmentation fault, if there isn't any "." character in the sought string.